### PR TITLE
discount range fix

### DIFF
--- a/src/chargily_lib/invoice.py
+++ b/src/chargily_lib/invoice.py
@@ -110,9 +110,9 @@ class Invoice(UserDict):
         if not isinstance(discount, (float, int)):
             raise BadConfigException("Discount should be type of int, float")
 
-        if 0 > discount or discount >= 1:
+        if 0 > discount or discount >= 100:
             raise BadConfigException(
-                "Discount should be bigger or equal 0 or smaller than 1"
+                "Discount should be bigger or equal 0 or smaller than 100"
             )
 
     # BACK_URL


### PR DESCRIPTION
there's a problem
when you give it a discount of "25"
it tells you it needs to be between 0 and 1
but when you give it a value on that range
it shows 0.25% on the chargily page

which means the range should be arount 0 to 100
Not 0 - 1